### PR TITLE
fix save_timeseries

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -67,12 +67,13 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
     tstart = 0.0
     tstop = 50.0
     Nsteps = 500
-    
+
     tstep = tstop / Nsteps
     tout = [tstep]
     idid = Int32[0]
     info = zeros(Int32, 20)
 
+    info[3] = save_timeseries
     info[11] = 0
     info[16] = 0    # == 1 to ignore algebraic variables in the error calculation
     info[17] = 0
@@ -83,7 +84,7 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
     rpar = [0.0]
     rtol = [reltol]
     atol = [abstol]
-    lrw = Int32[N[1]^3 + 9 * N[1] + 60 + 3 * nrt[1]] 
+    lrw = Int32[N[1]^3 + 9 * N[1] + 60 + 3 * nrt[1]]
     rwork = zeros(lrw[1])
     liw = Int32[2*N[1] + 40]
     iwork = zeros(Int32, liw[1])
@@ -101,24 +102,14 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
     u = copy(u0)
     du = copy(du0)
     # The Inner Loops : Style depends on save_timeseries
-    if save_timeseries
-        for k in 1:length(save_ts)
-            tout = [save_ts[k]]
-            while t[1] < save_ts[k]
-                DASKR.unsafe_solve(res, N, t, u, du, tout, info, rtol, atol, idid, rwork, lrw, iwork, liw, rpar, ipar, jac, psol, rt, nrt, jroot)
-                push!(ures,copy(u))
-                push!(ts, t[1])
-            end
+    for k in 1:length(save_ts)
+        tout = [save_ts[k]]
+        while t[1] < save_ts[k]
+            DASKR.unsafe_solve(res, N, t, u, du, tout, info, rtol, atol, idid, rwork, lrw, iwork, liw, rpar, ipar, jac, psol, rt, nrt, jroot)
+            push!(ures,copy(u))
+            push!(ts, t[1])
         end
-    else # save_timeseries == false, so use IDA_NORMAL style
-        for k in 2:length(save_ts)
-            # flag = @checkflag IDASolve(mem,
-            #                     save_ts[k], tout, utmp, dutmp, IDA_NORMAL)
-            # push!(ures,copy(utmp))
-        end
-        ts = save_ts
     end
-
     ### Finishing Routine
 
     timeseries = Vector{uType}(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ let
     Nsteps = 500
     abstol = 1e-4
     reltol = 1e-4
-    
+
     tstep = tstop / Nsteps
     tout = [tstep]
     idid = Int32[0]
@@ -34,7 +34,7 @@ let
     rpar = [0.0]
     rtol = [reltol]
     atol = [abstol]
-    lrw = Int32[N[1]^3 + 9 * N[1] + 60 + 3 * nrt[1]] 
+    lrw = Int32[N[1]^3 + 9 * N[1] + 60 + 3 * nrt[1]]
     rwork = zeros(lrw[1])
     liw = Int32[2*N[1] + 40]
     iwork = zeros(Int32, liw[1])
@@ -67,11 +67,14 @@ let
     dt = 1000
     saveat = float(collect(0:dt:100000))
     sol = solve(prob, DASKR.Algorithm())
+    sol = solve(prob, DASKR.Algorithm(),save_timeseries=false)
     sol = solve(prob, DASKR.Algorithm(), saveat = saveat, isdiff = [true, true, false])
-    sol = solve(prob, DASKR.Algorithm(), saveat = saveat)
-    
+    sol = solve(prob, DASKR.Algorithm(), saveat = saveat,
+                      save_timeseries = false,
+                      isdiff = [true, true, false])
+    sol = solve(prob, DASKR.Algorithm(), saveat = saveat, save_timeseries = false)
+
     @test intersect(sol.t, saveat) == saveat
-    
+
     @test sol.t == saveat
 end
-


### PR DESCRIPTION
I noticed that save_timeseries was used incorrectly before. In the common interface, it means that every internal step of the solver is saved. The change to make this work was simply changing `info[3] = save_timeseries`.

Note that the previous behavior is, as with all other common interface solvers, given by using `save_timeseries = false`. For example:

```julia
sol = solve(prob,DASKR(),save_timeseries=false,saveat=saveat)
```

only saves at each saveat location (using interpolations).

For reference, the reason why `save_timeseries = true` is the ecosystem default is because then `solve(prob)` "just works", which makes it very user-friendly to start (though I know physicists like the `saveat` style of choosing timepoints more!).