### PR TITLE
Change algorithm name

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -8,9 +8,10 @@ import DiffEqBase: solve
 abstract DASKRDAEAlgorithm{LinearSolver} <: AbstractDAEAlgorithm
 
 # DAE Algorithms
-immutable Algorithm{LinearSolver} <: DASKRDAEAlgorithm{LinearSolver} end
-Algorithm(;linear_solver=:Dense) = Algorithm{linear_solver}()
+immutable daskr{LinearSolver} <: DASKRDAEAlgorithm{LinearSolver} end
+daskr(;linear_solver=:Dense) = daskr{linear_solver}()
 
+export daskr
 
 ## Solve for DAEs uses raw_solver
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,13 +66,13 @@ let
     prob = DAEProblem(resrob,u0,du0,(0.0,100000.0))
     dt = 1000
     saveat = float(collect(0:dt:100000))
-    sol = solve(prob, DASKR.Algorithm())
-    sol = solve(prob, DASKR.Algorithm(),save_timeseries=false)
-    sol = solve(prob, DASKR.Algorithm(), saveat = saveat, isdiff = [true, true, false])
-    sol = solve(prob, DASKR.Algorithm(), saveat = saveat,
+    sol = solve(prob, daskr())
+    sol = solve(prob, daskr(),save_timeseries=false)
+    sol = solve(prob, daskr(), saveat = saveat, isdiff = [true, true, false])
+    sol = solve(prob, daskr(), saveat = saveat,
                       save_timeseries = false,
                       isdiff = [true, true, false])
-    sol = solve(prob, DASKR.Algorithm(), saveat = saveat, save_timeseries = false)
+    sol = solve(prob, daskr(), saveat = saveat, save_timeseries = false)
 
     @test intersect(sol.t, saveat) == saveat
 


### PR DESCRIPTION
This changes the name of the algorithm in the common interface to `daskr()` to match how other wrapper packages do it (`lsoda()`, `dopri5()`, `IDA()`, etc.). It also exports this type to match the way the other packages do it.