### PR TITLE
Common Interface Update

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 0.3.2
+DiffEqBase 0.15.0
 Compat 0.9.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,14 +67,17 @@ let
     dt = 1000
     saveat = float(collect(0:dt:100000))
     sol = solve(prob, daskr())
-    sol = solve(prob, daskr(),save_timeseries=false)
+    @test length(sol.t) > 2
+    sol = solve(prob, daskr(),save_everystep=false)
+    @test length(sol.u) == length(sol.t) == 2
     sol = solve(prob, daskr(), saveat = saveat, isdiff = [true, true, false])
-    sol = solve(prob, daskr(), saveat = saveat,
-                      save_timeseries = false,
-                      isdiff = [true, true, false])
-    sol = solve(prob, daskr(), saveat = saveat, save_timeseries = false)
-
-    @test intersect(sol.t, saveat) == saveat
-
     @test sol.t == saveat
+    sol = solve(prob, daskr(), saveat = dt, isdiff = [true, true, false])
+    @test sol.t == saveat
+    sol = solve(prob, daskr(), saveat = saveat,
+                      save_everystep = true,
+                      isdiff = [true, true, false])
+    @test minimum([t ∈ sol.t for t in saveat])
+    sol = solve(prob, daskr(), saveat = saveat, save_everystep = true)
+    @test intersect(sol.t, saveat) == saveat
 end


### PR DESCRIPTION
This updates the common interface to the new specs for DiffEqBase.jl's v0.15.0. It is incompatible with previous versions. This should not be merged until DiffEqBase.jl v0.15.0 is released, and upper bounds are placed in METADATA.